### PR TITLE
Remove z-index: -1 on

### DIFF
--- a/assets/sass/now-ui-kit/plugins/_plugin-datepicker.scss
+++ b/assets/sass/now-ui-kit/plugins/_plugin-datepicker.scss
@@ -114,7 +114,6 @@
   font-weight: $font-weight-light;
   font-size: $font-size-base;
   border: none;
-  z-index: -1;
   position: relative;
   cursor: pointer;
 }


### PR DESCRIPTION
Removed 'z-index: -1;' on '.datepicker .day div, .datepicker th' as this was causing usability issue with Date Picker widget in Firefox.
Tested with change in Chrome, no issue seemed to be introduced.