### PR TITLE
fixing btn-neutral.disabled color

### DIFF
--- a/assets/css/now-ui-kit.css
+++ b/assets/css/now-ui-kit.css
@@ -2041,6 +2041,7 @@ fieldset[disabled] .btn-neutral:active,
 fieldset[disabled] .btn-neutral.active {
     background-color: #FFFFFF;
     border-color: #FFFFFF;
+    color: #000000;
 }
 
 .btn-neutral.btn-danger {
@@ -4276,7 +4277,7 @@ Created using IcoMoon - icomoon.io
 
 
 /*------------------------
-	base class definition
+  base class definition
 -------------------------*/
 
 .now-ui-icons {
@@ -4390,7 +4391,7 @@ Created using IcoMoon - icomoon.io
 
 
 /*------------------------
-	font icons
+  font icons
 -------------------------*/
 
 .now-ui-icons.ui-1_check:before {


### PR DESCRIPTION
Fixing `btn-neutral.disabled` color. `btn-neutral` original font is `#f96332`, but when the btn-neutral is disabled, you cannot see the text color. Here is what http://demos.creative-tim.com/now-ui-kit-pro/examples/pricing.html currently looks like now...
![pricing-page-original](https://user-images.githubusercontent.com/8698357/36060448-2ae130ec-0e07-11e8-9695-0fcf813749cd.png)

Added color black to the `btn-neutral.disabled` button. Here is what it looks like after...
![pricing-page-modified](https://user-images.githubusercontent.com/8698357/36060461-56c1e3d2-0e07-11e8-8146-97c596fec5da.png)


