### PR TITLE
Fix incorrect borders in input group

### DIFF
--- a/assets/scss/now-ui-kit/_inputs.scss
+++ b/assets/scss/now-ui-kit/_inputs.scss
@@ -233,13 +233,13 @@
   }
 }
 
-.input-group .form-control:first-child,
+.input-group .form-control:first-of-type,
 .input-group-text:first-child,
 .input-group-btn:first-child > .dropdown-toggle,
 .input-group-btn:last-child > .btn:not(:last-child):not(.dropdown-toggle) {
     border-right: 0 none;
 }
-.input-group .form-control:last-child,
+.input-group .form-control:last-of-type,
 .input-group-text:last-child,
 .input-group-btn:last-child > .dropdown-toggle,
 .input-group-btn:first-child > .btn:not(:first-child) {


### PR DESCRIPTION
If there is both an `input-group-prepend` and `input-group-append` in an input group, the form control incorrectly renders borders on both sides. This PR solves this by attaching the border removal to `:first-of-type` and `:last-of-type` instead of `:first-child` and `:last-child` respectively.