### PR TITLE
Made checkbox sign work with non-adjacent .form-check-sign

### DIFF
--- a/assets/scss/now-ui-kit/_checkboxes-radio.scss
+++ b/assets/scss/now-ui-kit/_checkboxes-radio.scss
@@ -65,7 +65,7 @@
   position: absolute;
   visibility: hidden;
 }
-.form-check input[type="checkbox"]:checked + .form-check-sign::after{
+.form-check input[type="checkbox"]:checked ~ .form-check-sign::after{
   opacity: 1;
 }
 


### PR DESCRIPTION
Situations where `.form-check input[type="checkbox"]:checked` and `.form-check-sign` aren't adjacent siblings, the styles tick wouldn't be displayed such as in:

    <input
      class="form-check-input"
      type="checkbox">
    Info
    <small>(sub-info)</small>
    <span class="form-check-sign">
        <span class="check"></span>
    </span>

Now it will work in situations like this as well